### PR TITLE
Fix conflicting ConfigMap names

### DIFF
--- a/controllers/synapse/synapse_controller.go
+++ b/controllers/synapse/synapse_controller.go
@@ -341,13 +341,12 @@ func (r *SynapseReconciler) createPostgresClusterForSynapse(
 	createdPostgresCluster := pgov1beta1.PostgresCluster{}
 
 	// Create ConfigMap for PostgresCluster
-	objectMeta = setObjectMeta(synapse.Name, synapse.Namespace, map[string]string{})
+	objectMeta = setObjectMeta(synapse.Name+"-pgsql", synapse.Namespace, map[string]string{})
 	if err := r.reconcileResource(ctx, r.configMapForPostgresCluster, &synapse, &corev1.ConfigMap{}, objectMeta); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// Create PostgresCluster for Synapse
-	objectMeta = setObjectMeta(synapse.Name, synapse.Namespace, map[string]string{})
 	if err := r.reconcileResource(ctx, r.postgresClusterForSynapse, &synapse, &createdPostgresCluster, objectMeta); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -427,8 +426,8 @@ func (r *SynapseReconciler) updateSynapseStatusWithPostgreSQLInfos(
 	if err := r.Get(
 		ctx,
 		types.NamespacedName{
-			Name:      s.Name + "-pguser-synapse",
-			Namespace: s.Namespace,
+			Name:      createdPostgresCluster.Name + "-pguser-synapse",
+			Namespace: createdPostgresCluster.Namespace,
 		},
 		&postgresSecret,
 	); err != nil {

--- a/controllers/synapse/synapse_controller_test.go
+++ b/controllers/synapse/synapse_controller_test.go
@@ -697,9 +697,15 @@ var _ = Describe("Integration tests for the Synapse controller", Ordered, Label(
 				When("Requesting a new PostgreSQL instance to be created for Synapse", func() {
 					var createdPostgresCluster *pgov1beta1.PostgresCluster
 					var postgresSecret corev1.Secret
+					var postgresLookupKeys types.NamespacedName
 
 					BeforeAll(func() {
 						initSynapseVariables()
+
+						postgresLookupKeys = types.NamespacedName{
+							Name:      synapseLookupKey.Name + "-pgsql",
+							Namespace: synapseLookupKey.Namespace,
+						}
 
 						// Init variable
 						createdPostgresCluster = &pgov1beta1.PostgresCluster{}
@@ -729,7 +735,7 @@ var _ = Describe("Integration tests for the Synapse controller", Ordered, Label(
 						// we have to manually create this secret here.
 						postgresSecret = corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      SynapseName + "-pguser-synapse",
+								Name:      SynapseName + "-pgsql-pguser-synapse",
 								Namespace: SynapseNamespace,
 							},
 							Data: map[string][]byte{
@@ -756,7 +762,7 @@ var _ = Describe("Integration tests for the Synapse controller", Ordered, Label(
 
 					AfterAll(func() {
 						By("Cleaning up the Synapse PostgresCluster")
-						deleteResource(createdPostgresCluster, synapseLookupKey, false)
+						deleteResource(createdPostgresCluster, postgresLookupKeys, false)
 
 						cleanupSynapseResources()
 						cleanupSynapseConfigMap()
@@ -764,7 +770,7 @@ var _ = Describe("Integration tests for the Synapse controller", Ordered, Label(
 
 					It("Should create a PostgresCluster for Synapse", func() {
 						By("Checking that a Synapse PostgresCluster exists")
-						checkResourcePresence(createdPostgresCluster, synapseLookupKey, expectedOwnerReference)
+						checkResourcePresence(createdPostgresCluster, postgresLookupKeys, expectedOwnerReference)
 					})
 
 					It("Should update the Synapse status", func() {


### PR DESCRIPTION
The ConfigMap for PostgreSQL and the ConfigMap for Synapse were using
the same name. This has been fixed by appending "-pgsql" to all
PostgreSQL resources.