### PR TITLE
Ensure user-provided ConfigMaps are not modified

### DIFF
--- a/apis/synapse/v1alpha1/synapse_types.go
+++ b/apis/synapse/v1alpha1/synapse_types.go
@@ -64,10 +64,7 @@ type SynapseHomeserverConfigMap struct {
 	Name string `json:"name"`
 
 	// Namespace in which the ConfigMap is living. If left empty, the Synapse
-	// namespace is used. Currently the ConfigMap must live in the same
-	// namespace as the Synapse instance referencing it, therefore this
-	// attribute is not used.
-	// See https://github.com/opdev/synapse-operator/issues/17
+	// namespace is used.
 	Namespace string `json:"namespace,omitempty"`
 }
 
@@ -90,8 +87,7 @@ type SynapseBridges struct {
 	// * enable the bridge, without specifying additional configuration
 	//   options. The bridge will be deployed with a default configuration.
 	// * enable the bridge and specify an existing ConfigMap by its Name and
-	//   Namespace containing a heisenbridge.yaml. This ConfigMap will be
-	//   modified in place to configure the correct homeserver connection URL.
+	//   Namespace containing a heisenbridge.yaml.
 	Heisenbridge SynapseHeisenbridge `json:"heisenbridge,omitempty"`
 }
 
@@ -103,8 +99,7 @@ type SynapseHeisenbridge struct {
 
 	// Holds information about the ConfigMap containing the heisenbridge.yaml
 	// configuration file to be used as input for the configuration of the
-	// Heisenbridge IRC Bridge. Note that this ConfigMap will be modified by
-	// the Synapse controller.
+	// Heisenbridge IRC Bridge.
 	ConfigMap SynapseHeisenbridgeConfigMap `json:"configMap,omitempty"`
 
 	// +kubebuilder:default:=0
@@ -124,10 +119,7 @@ type SynapseHeisenbridgeConfigMap struct {
 	Name string `json:"name"`
 
 	// Namespace in which the ConfigMap is living. If left empty, the Synapse
-	// namespace is used. Currently the ConfigMap must live in the same
-	// namespace as the Synapse instance referencing it, therefore this
-	// attribute is not used.
-	// See https://github.com/opdev/synapse-operator/issues/17
+	// namespace is used.
 	Namespace string `json:"namespace,omitempty"`
 }
 
@@ -144,10 +136,6 @@ type SynapseStatus struct {
 
 	// Holds configuration information for Synapse
 	HomeserverConfiguration SynapseStatusHomeserverConfiguration `json:"homeserverConfiguration,omitempty"`
-
-	// The name of the ConfigMap, in the synapse Namespace, which contains the
-	// homeserver.yaml configuration file
-	HomeserverConfigMapName string `json:"homeserverConfigMapName,omitempty"`
 
 	// Synapse IP address (corresponding to the Synapse Service IP address)
 	IP string `json:"ip,omitempty"`
@@ -167,9 +155,6 @@ type SynapseStatusBridgesConfiguration struct {
 type SynapseStatusHeisenbridge struct {
 	// IP at which the Heisenbridge is available
 	IP string `json:"ip,omitempty"`
-
-	// Name of the ConfigMap used for Heisenbridge configuration
-	ConfigMapName string `json:"configMapName,omitempty"`
 }
 
 type SynapseStatusDatabaseConnectionInfo struct {

--- a/bundle/manifests/synapse.opdev.io_synapses.yaml
+++ b/bundle/manifests/synapse.opdev.io_synapses.yaml
@@ -43,25 +43,19 @@ spec:
                       * enable the bridge, without specifying additional configuration   options.
                       The bridge will be deployed with a default configuration. *
                       enable the bridge and specify an existing ConfigMap by its Name
-                      and   Namespace containing a heisenbridge.yaml. This ConfigMap
-                      will be   modified in place to configure the correct homeserver
-                      connection URL.'
+                      and   Namespace containing a heisenbridge.yaml.'
                     properties:
                       configMap:
                         description: Holds information about the ConfigMap containing
                           the heisenbridge.yaml configuration file to be used as input
-                          for the configuration of the Heisenbridge IRC Bridge. Note
-                          that this ConfigMap will be modified by the Synapse controller.
+                          for the configuration of the Heisenbridge IRC Bridge.
                         properties:
                           name:
                             description: Name of the ConfigMap in the given Namespace.
                             type: string
                           namespace:
                             description: Namespace in which the ConfigMap is living.
-                              If left empty, the Synapse namespace is used. Currently
-                              the ConfigMap must live in the same namespace as the
-                              Synapse instance referencing it, therefore this attribute
-                              is not used. See https://github.com/opdev/synapse-operator/issues/17
+                              If left empty, the Synapse namespace is used.
                             type: string
                         required:
                         - name
@@ -104,10 +98,7 @@ spec:
                         type: string
                       namespace:
                         description: Namespace in which the ConfigMap is living. If
-                          left empty, the Synapse namespace is used. Currently the
-                          ConfigMap must live in the same namespace as the Synapse
-                          instance referencing it, therefore this attribute is not
-                          used. See https://github.com/opdev/synapse-operator/issues/17
+                          left empty, the Synapse namespace is used.
                         type: string
                     required:
                     - name
@@ -140,9 +131,6 @@ spec:
                   heisenbridge:
                     description: Status of the Heisenbridge
                     properties:
-                      configMapName:
-                        description: Name of the ConfigMap used for Heisenbridge configuration
-                        type: string
                       ip:
                         description: IP at which the Heisenbridge is available
                         type: string
@@ -167,10 +155,6 @@ spec:
                     description: User allowed to query the given database
                     type: string
                 type: object
-              homeserverConfigMapName:
-                description: The name of the ConfigMap, in the synapse Namespace,
-                  which contains the homeserver.yaml configuration file
-                type: string
               homeserverConfiguration:
                 description: Holds configuration information for Synapse
                 properties:

--- a/config/crd/bases/synapse.opdev.io_synapses.yaml
+++ b/config/crd/bases/synapse.opdev.io_synapses.yaml
@@ -45,25 +45,19 @@ spec:
                       * enable the bridge, without specifying additional configuration   options.
                       The bridge will be deployed with a default configuration. *
                       enable the bridge and specify an existing ConfigMap by its Name
-                      and   Namespace containing a heisenbridge.yaml. This ConfigMap
-                      will be   modified in place to configure the correct homeserver
-                      connection URL.'
+                      and   Namespace containing a heisenbridge.yaml.'
                     properties:
                       configMap:
                         description: Holds information about the ConfigMap containing
                           the heisenbridge.yaml configuration file to be used as input
-                          for the configuration of the Heisenbridge IRC Bridge. Note
-                          that this ConfigMap will be modified by the Synapse controller.
+                          for the configuration of the Heisenbridge IRC Bridge.
                         properties:
                           name:
                             description: Name of the ConfigMap in the given Namespace.
                             type: string
                           namespace:
                             description: Namespace in which the ConfigMap is living.
-                              If left empty, the Synapse namespace is used. Currently
-                              the ConfigMap must live in the same namespace as the
-                              Synapse instance referencing it, therefore this attribute
-                              is not used. See https://github.com/opdev/synapse-operator/issues/17
+                              If left empty, the Synapse namespace is used.
                             type: string
                         required:
                         - name
@@ -101,10 +95,7 @@ spec:
                         type: string
                       namespace:
                         description: Namespace in which the ConfigMap is living. If
-                          left empty, the Synapse namespace is used. Currently the
-                          ConfigMap must live in the same namespace as the Synapse
-                          instance referencing it, therefore this attribute is not
-                          used. See https://github.com/opdev/synapse-operator/issues/17
+                          left empty, the Synapse namespace is used.
                         type: string
                     required:
                     - name
@@ -137,9 +128,6 @@ spec:
                   heisenbridge:
                     description: Status of the Heisenbridge
                     properties:
-                      configMapName:
-                        description: Name of the ConfigMap used for Heisenbridge configuration
-                        type: string
                       ip:
                         description: IP at which the Heisenbridge is available
                         type: string
@@ -164,10 +152,6 @@ spec:
                     description: User allowed to query the given database
                     type: string
                 type: object
-              homeserverConfigMapName:
-                description: The name of the ConfigMap, in the synapse Namespace,
-                  which contains the homeserver.yaml configuration file
-                type: string
               homeserverConfiguration:
                 description: Holds configuration information for Synapse
                 properties:

--- a/controllers/synapse/configmap_utils.go
+++ b/controllers/synapse/configmap_utils.go
@@ -23,6 +23,7 @@ import (
 	synapsev1alpha1 "github.com/opdev/synapse-operator/apis/synapse/v1alpha1"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -129,4 +130,34 @@ func (r *SynapseReconciler) writeYAMLFileToConfigMapData(
 
 	r.writeFileToConfigMapData(configMap, filename, string(bytesContent))
 	return nil
+}
+
+// getConfigMapCopy is a generic function which creates a copy of a given
+// source ConfigMap. The resulting copy is a ConfigMap with similar data, and
+// with metadata set by the 'copyConfigMapObjectMeta' argument.
+func (r *SynapseReconciler) getConfigMapCopy(
+	sourceConfigMapName string,
+	sourceConfigMapNamespace string,
+	copyConfigMapObjectMeta metav1.ObjectMeta,
+) (*corev1.ConfigMap, error) {
+	sourceConfigMap := &corev1.ConfigMap{}
+
+	ctx := context.TODO()
+
+	// Get sourceConfigMap
+	if err := r.Get(
+		ctx,
+		types.NamespacedName{Name: sourceConfigMapName, Namespace: sourceConfigMapNamespace},
+		sourceConfigMap,
+	); err != nil {
+		return &corev1.ConfigMap{}, err
+	}
+
+	// Create a copy of the source ConfigMap with the same content.
+	copyConfigMap := &corev1.ConfigMap{
+		ObjectMeta: copyConfigMapObjectMeta,
+		Data:       sourceConfigMap.Data,
+	}
+
+	return copyConfigMap, nil
 }

--- a/controllers/synapse/configmap_utils.go
+++ b/controllers/synapse/configmap_utils.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package synapse
 
+/* This file puts together generic functions for ConfiMap manipulation */
 import (
 	"context"
 	"errors"
@@ -27,8 +28,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// Defines a function type. Functions of the updateDataFunc type implements the
+// logic to update the data of a configmap, defined by the 'data' argument.
 type updateDataFunc func(s synapsev1alpha1.Synapse, data map[string]interface{}) error
 
+// A generic function to update an existing ConfigMap. It takes as arguments:
+// * The context
+// * The name of the ConfigMap to update
+// * The Synapse object being reconciled
+// * The function to be called to actually update the ConfigMap's content
+// * The name of the file to update in the ConfigMap
 func (r *SynapseReconciler) updateConfigMap(
 	ctx context.Context,
 	cm *corev1.ConfigMap,

--- a/controllers/synapse/configmap_utils.go
+++ b/controllers/synapse/configmap_utils.go
@@ -45,7 +45,9 @@ func (r *SynapseReconciler) updateConfigMap(
 		return err
 	}
 
-	r.updateConfigMapData(cm, s, updateData, filename)
+	if err := r.updateConfigMapData(cm, s, updateData, filename); err != nil {
+		return err
+	}
 
 	// Update ConfigMap
 	if err := r.Client.Update(ctx, cm); err != nil {

--- a/controllers/synapse/synapse_configmap.go
+++ b/controllers/synapse/synapse_configmap.go
@@ -2752,6 +2752,7 @@ func (r *SynapseReconciler) ParseHomeserverConfigMap(ctx context.Context, synaps
 		return err
 	}
 
+	// Populate the Status.HomeserverConfiguration with values defined in homeserver.yaml
 	synapse.Status.HomeserverConfiguration.ServerName = server_name
 	synapse.Status.HomeserverConfiguration.ReportStats = report_stats
 
@@ -2836,6 +2837,10 @@ func (r *SynapseReconciler) fetchDatabaseDataFromSynapseStatus(s synapsev1alpha1
 	return databaseDataMap, nil
 }
 
+// updateHomeserverWithHeisenbridgeInfos is a function of type updateDataFunc
+// function to be passed as an argument in a call to updateConfigMap.
+//
+// It enables the Heisenbridge as an AppService in Synapse.
 func (r *SynapseReconciler) updateHomeserverWithHeisenbridgeInfos(
 	s synapsev1alpha1.Synapse,
 	homeserver map[string]interface{},

--- a/controllers/synapse/synapse_heisenbridge_configmap.go
+++ b/controllers/synapse/synapse_heisenbridge_configmap.go
@@ -82,6 +82,11 @@ func (r *SynapseReconciler) configMapForHeisenbridgeCopy(
 	return copyConfigMap, nil
 }
 
+// updateHeisenbridgeWithURL is a function of type updateDataFunc function to
+// be passed as an argument in a call to updateConfigMap.
+//
+// It configures the correct Heisenbridge URL, needed for Synapse to reach the
+// bridge.
 func (r *SynapseReconciler) updateHeisenbridgeWithURL(
 	s synapsev1alpha1.Synapse,
 	heisenbridge map[string]interface{},

--- a/controllers/synapse/synapse_heisenbridge_service.go
+++ b/controllers/synapse/synapse_heisenbridge_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 // serviceForSynapse returns a synapse Service object
-func (r *SynapseReconciler) serviceForHeisenbridge(s *synapsev1alpha1.Synapse, objectMeta metav1.ObjectMeta) client.Object {
+func (r *SynapseReconciler) serviceForHeisenbridge(s *synapsev1alpha1.Synapse, objectMeta metav1.ObjectMeta) (client.Object, error) {
 	service := &corev1.Service{
 		ObjectMeta: objectMeta,
 		Spec: corev1.ServiceSpec{
@@ -42,6 +42,8 @@ func (r *SynapseReconciler) serviceForHeisenbridge(s *synapsev1alpha1.Synapse, o
 		},
 	}
 	// Set Synapse instance as the owner and controller
-	ctrl.SetControllerReference(s, service, r.Scheme)
-	return service
+	if err := ctrl.SetControllerReference(s, service, r.Scheme); err != nil {
+		return &corev1.Service{}, err
+	}
+	return service, nil
 }

--- a/controllers/synapse/synapse_pvc.go
+++ b/controllers/synapse/synapse_pvc.go
@@ -27,7 +27,7 @@ import (
 )
 
 // persistentVolumeClaimForSynapse returns a synapse PVC object
-func (r *SynapseReconciler) persistentVolumeClaimForSynapse(s *synapsev1alpha1.Synapse, objectMeta metav1.ObjectMeta) client.Object {
+func (r *SynapseReconciler) persistentVolumeClaimForSynapse(s *synapsev1alpha1.Synapse, objectMeta metav1.ObjectMeta) (client.Object, error) {
 	pvcmode := corev1.PersistentVolumeFilesystem
 
 	pvc := &corev1.PersistentVolumeClaim{
@@ -44,6 +44,8 @@ func (r *SynapseReconciler) persistentVolumeClaimForSynapse(s *synapsev1alpha1.S
 	}
 
 	// Set Synapse instance as the owner and controller
-	ctrl.SetControllerReference(s, pvc, r.Scheme)
-	return pvc
+	if err := ctrl.SetControllerReference(s, pvc, r.Scheme); err != nil {
+		return &corev1.PersistentVolumeClaim{}, err
+	}
+	return pvc, nil
 }

--- a/controllers/synapse/synapse_service.go
+++ b/controllers/synapse/synapse_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 // serviceForSynapse returns a synapse Service object
-func (r *SynapseReconciler) serviceForSynapse(s *synapsev1alpha1.Synapse, objectMeta metav1.ObjectMeta) client.Object {
+func (r *SynapseReconciler) serviceForSynapse(s *synapsev1alpha1.Synapse, objectMeta metav1.ObjectMeta) (client.Object, error) {
 	service := &corev1.Service{
 		ObjectMeta: objectMeta,
 		Spec: corev1.ServiceSpec{
@@ -42,6 +42,8 @@ func (r *SynapseReconciler) serviceForSynapse(s *synapsev1alpha1.Synapse, object
 		},
 	}
 	// Set Synapse instance as the owner and controller
-	ctrl.SetControllerReference(s, service, r.Scheme)
-	return service
+	if err := ctrl.SetControllerReference(s, service, r.Scheme); err != nil {
+		return &corev1.Service{}, err
+	}
+	return service, nil
 }

--- a/controllers/synapse/synapse_serviceaccount.go
+++ b/controllers/synapse/synapse_serviceaccount.go
@@ -27,18 +27,20 @@ import (
 )
 
 // serviceAccountForSynapse returns a synapse ServiceAccount object
-func (r *SynapseReconciler) serviceAccountForSynapse(s *synapsev1alpha1.Synapse, objectMeta metav1.ObjectMeta) client.Object {
+func (r *SynapseReconciler) serviceAccountForSynapse(s *synapsev1alpha1.Synapse, objectMeta metav1.ObjectMeta) (client.Object, error) {
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: objectMeta,
 	}
 
 	// Set Synapse instance as the owner and controller
-	ctrl.SetControllerReference(s, sa, r.Scheme)
-	return sa
+	if err := ctrl.SetControllerReference(s, sa, r.Scheme); err != nil {
+		return &corev1.ServiceAccount{}, err
+	}
+	return sa, nil
 }
 
 // roleBindingForSynapse returns a synapse RoleBinding object
-func (r *SynapseReconciler) roleBindingForSynapse(s *synapsev1alpha1.Synapse, objectMeta metav1.ObjectMeta) client.Object {
+func (r *SynapseReconciler) roleBindingForSynapse(s *synapsev1alpha1.Synapse, objectMeta metav1.ObjectMeta) (client.Object, error) {
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: objectMeta,
 		RoleRef: rbacv1.RoleRef{
@@ -54,6 +56,8 @@ func (r *SynapseReconciler) roleBindingForSynapse(s *synapsev1alpha1.Synapse, ob
 	}
 
 	// Set Synapse instance as the owner and controller
-	ctrl.SetControllerReference(s, rb, r.Scheme)
-	return rb
+	if err := ctrl.SetControllerReference(s, rb, r.Scheme); err != nil {
+		return &rbacv1.RoleBinding{}, err
+	}
+	return rb, nil
 }


### PR DESCRIPTION
This commit adds the creation of configMaps for the homeserver.yaml and
heisenbridge.yaml configuration files, even if the user has provided
such a file. We now consider that user-provided ConfigMaps are not to be
owned (and therefore modified) by the controller.

closes #17