### PR TITLE
Complete branch renaming from master to main

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,9 +2,9 @@ name: Run unit and integration tests
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ deployment.apps "synapse-operator-controller-manager" deleted
 
 A set of example how to use the Synapse operator to deploy a Synapse server is
 provided under the
-[examples](https://github.com/opdev/synapse-operator/tree/master/examples)
+[examples](https://github.com/opdev/synapse-operator/tree/main/examples)
 directory.
 
 ## Notes and pre-requisites


### PR DESCRIPTION
This fixes the end to end github workflow, that wasn't running anymore.