### PR TITLE
Allow live edit of homeserver config file

### DIFF
--- a/internal/controller/synapse/synapse/synapse_controller_test.go
+++ b/internal/controller/synapse/synapse/synapse_controller_test.go
@@ -456,7 +456,7 @@ var _ = Describe("Integration tests for the Synapse controller", Ordered, Label(
 					By("Checking that a Synapse Deployment exists and is correctly configured")
 					checkResourcePresence(createdDeployment, synapseLookupKey, expectedOwnerReference)
 
-					By("Checking that initContainers contains the required environment variables")
+					By("Checking that initContainer for generating config file contains the required environment variables")
 					envVars := []corev1.EnvVar{{
 						Name:  "SYNAPSE_SERVER_NAME",
 						Value: ServerName,
@@ -464,7 +464,7 @@ var _ = Describe("Integration tests for the Synapse controller", Ordered, Label(
 						Name:  "SYNAPSE_REPORT_STATS",
 						Value: utils.BoolToYesNo(ReportStats),
 					}}
-					Expect(createdDeployment.Spec.Template.Spec.InitContainers[0].Env).Should(ContainElements(envVars))
+					Expect(createdDeployment.Spec.Template.Spec.InitContainers[1].Env).Should(ContainElements(envVars))
 				})
 
 				It("Should create a Synapse Service", func() {
@@ -557,7 +557,7 @@ var _ = Describe("Integration tests for the Synapse controller", Ordered, Label(
 						By("Checking that a Synapse Deployment exists and is correctly configured")
 						checkResourcePresence(createdDeployment, synapseLookupKey, expectedOwnerReference)
 
-						By("Checking that initContainers contains the required environment variables")
+						By("Checking that initContainer for generating config file contains the required environment variables")
 						envVars := []corev1.EnvVar{{
 							Name:  "SYNAPSE_SERVER_NAME",
 							Value: ServerName,
@@ -565,7 +565,7 @@ var _ = Describe("Integration tests for the Synapse controller", Ordered, Label(
 							Name:  "SYNAPSE_REPORT_STATS",
 							Value: utils.BoolToYesNo(ReportStats),
 						}}
-						Expect(createdDeployment.Spec.Template.Spec.InitContainers[0].Env).Should(ContainElements(envVars))
+						Expect(createdDeployment.Spec.Template.Spec.InitContainers[1].Env).Should(ContainElements(envVars))
 					})
 
 					It("Should create a Synapse Service", func() {

--- a/internal/templates/synapse_deployment.yaml
+++ b/internal/templates/synapse_deployment.yaml
@@ -21,19 +21,31 @@ spec:
       serviceAccountName: {{ .Values.Name }}
       {{- end }}
       initContainers:
+        # Copy homeserver.yaml from read-only ConfigMap to writable PV
+        # This allows manual editing of the configuration
+        - image: registry.access.redhat.com/ubi8/ubi-minimal:8.10
+          name: "copy-homeserver-config"
+          args:
+          - if [ ! -f /data/homeserver.yaml ]; then cp /data-homeserver/homeserver.yaml /data/homeserver.yaml; fi
+          command:
+          - bin/sh
+          - -c
+          volumeMounts:
+            - name: homeserver
+              mountPath: /data-homeserver
+            - name: data-pv
+              mountPath: /data
         - image: "matrixdotorg/synapse:v1.133.0"
           name: "synapse-generate"
           args: [ "generate" ]
           env:
             - name: SYNAPSE_CONFIG_PATH
-              value: /data-homeserver/homeserver.yaml
+              value: /data/homeserver.yaml
             - name: SYNAPSE_SERVER_NAME
               value: {{ .Values.Status.HomeserverConfiguration.ServerName }}
             - name: SYNAPSE_REPORT_STATS
               value: {{ if .Values.Status.HomeserverConfiguration.ReportStats }}"yes"{{ else }}"no"{{ end }}
           volumeMounts:
-            - name: homeserver
-              mountPath: /data-homeserver
             - name: data-pv
               mountPath: /data
         {{ if .Values.Status.Bridges.MautrixSignal.Enabled -}}
@@ -53,7 +65,7 @@ spec:
           name: "synapse"
           env:
             - name: SYNAPSE_CONFIG_PATH
-              value: /data-homeserver/homeserver.yaml
+              value: /data/homeserver.yaml
           volumeMounts:
             - name: homeserver
               mountPath: /data-homeserver


### PR DESCRIPTION
This is achieved by adding an initContainer that copies the homeserver.yaml from the read-only configMap to the writable PV.

Fix #36

Assisted-by: claude-4-sonnet